### PR TITLE
fix: recover from dying server and always open browser in client path

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -208,6 +208,8 @@ async function waitForSSEDecision(
   }
 }
 
+class RetryableError extends Error {}
+
 async function clientPath(
   port: number,
   sessionId: string,
@@ -237,11 +239,20 @@ async function clientPath(
   console.error(
     `IPE ${VERSION} registered with server at http://localhost:${port}`,
   );
+  openBrowser(`http://localhost:${port}`);
 
+  const sseStartedAt = Date.now();
   try {
     const decision = await waitForSSEDecision(port, sessionId);
     outputDecision(decision.behavior, decision.feedback, decision.acceptMode);
   } catch (err) {
+    const elapsed = Date.now() - sseStartedAt;
+    if (elapsed < 2000) {
+      console.error(
+        `IPE: SSE failed after ${elapsed}ms — server likely died, retrying`,
+      );
+      throw new RetryableError();
+    }
     console.error(`IPE: lost connection to server: ${err}`);
     outputDecision(
       "deny",
@@ -300,8 +311,8 @@ async function main() {
   if (server) {
     // We're the server owner
     const cleanup = () => {
-      removeLock();
       server.stop();
+      removeLock();
       process.exit(0);
     };
     process.on("SIGINT", cleanup);
@@ -325,19 +336,83 @@ async function main() {
     await server.waitForDrain();
     // Grace period: allow in-flight SSE responses to be read by clients
     await new Promise((r) => setTimeout(r, 500));
-    removeLock();
     server.stop();
+    removeLock();
     setTimeout(() => process.exit(0), 50);
   } else {
     // Server already running — join as client
-    await clientPath(
-      port,
-      sessionId,
-      plan,
-      permissionMode,
-      previousPlans,
-      fileSnippets,
-    );
+    try {
+      await clientPath(
+        port,
+        sessionId,
+        plan,
+        permissionMode,
+        previousPlans,
+        fileSnippets,
+      );
+    } catch (err) {
+      if (err instanceof RetryableError) {
+        // Server likely died — wait for port to free, then retry once
+        await new Promise((r) => setTimeout(r, 300));
+        const retry = await findOrStartServer(
+          VERSION,
+          latestVersion || undefined,
+        );
+        if (retry.server) {
+          const cleanup = () => {
+            retry.server!.stop();
+            removeLock();
+            process.exit(0);
+          };
+          process.on("SIGINT", cleanup);
+          process.on("SIGTERM", cleanup);
+
+          const decisionPromise = retry.server.addSession({
+            sessionId,
+            plan,
+            permissionMode,
+            previousPlans,
+            fileSnippets,
+          });
+
+          const url = `http://localhost:${retry.port}`;
+          console.error(`IPE ${VERSION} running at ${url}`);
+          openBrowser(url);
+
+          const decision = await decisionPromise;
+          outputDecision(
+            decision.behavior,
+            decision.feedback,
+            decision.acceptMode,
+          );
+
+          await retry.server.waitForDrain();
+          await new Promise((r) => setTimeout(r, 500));
+          retry.server.stop();
+          removeLock();
+          setTimeout(() => process.exit(0), 50);
+        } else {
+          // Another server appeared — join it without further retry
+          try {
+            await clientPath(
+              retry.port,
+              sessionId,
+              plan,
+              permissionMode,
+              previousPlans,
+              fileSnippets,
+            );
+          } catch {
+            outputDecision(
+              "deny",
+              "IPE server disconnected after retry. Please retry.",
+            );
+          }
+        }
+      } else {
+        throw err;
+      }
+    }
   }
 }
 
@@ -369,11 +444,20 @@ async function diffReviewClientPath(
   console.error(
     `IPE ${VERSION} registered with server at http://localhost:${port}`,
   );
+  openBrowser(`http://localhost:${port}`);
 
+  const sseStartedAt = Date.now();
   try {
     const decision = await waitForSSEDecision(port, sessionId);
     outputDecision(decision.behavior, decision.feedback, decision.acceptMode);
   } catch (err) {
+    const elapsed = Date.now() - sseStartedAt;
+    if (elapsed < 2000) {
+      console.error(
+        `IPE: SSE failed after ${elapsed}ms — server likely died, retrying`,
+      );
+      throw new RetryableError();
+    }
     console.error(`IPE: lost connection to server: ${err}`);
     outputDecision(
       "deny",
@@ -425,8 +509,8 @@ async function diffReviewMain() {
 
   if (server) {
     const cleanup = () => {
-      removeLock();
       server.stop();
+      removeLock();
       process.exit(0);
     };
     process.on("SIGINT", cleanup);
@@ -450,11 +534,67 @@ async function diffReviewMain() {
 
     await server.waitForDrain();
     await new Promise((r) => setTimeout(r, 500));
-    removeLock();
     server.stop();
+    removeLock();
     setTimeout(() => process.exit(0), 50);
   } else {
-    await diffReviewClientPath(port, sessionId, fileDiffs, cwd);
+    try {
+      await diffReviewClientPath(port, sessionId, fileDiffs, cwd);
+    } catch (err) {
+      if (err instanceof RetryableError) {
+        await new Promise((r) => setTimeout(r, 300));
+        const retry = await findOrStartServer(
+          VERSION,
+          latestVersion || undefined,
+        );
+        if (retry.server) {
+          const cleanup = () => {
+            retry.server!.stop();
+            removeLock();
+            process.exit(0);
+          };
+          process.on("SIGINT", cleanup);
+          process.on("SIGTERM", cleanup);
+
+          const decisionPromise = retry.server.addSession({
+            sessionId,
+            plan: "",
+            permissionMode: "review",
+            mode: "diff-review",
+            fileDiffs,
+            cwd,
+          });
+
+          const url = `http://localhost:${retry.port}`;
+          console.error(`IPE ${VERSION} running at ${url}`);
+          openBrowser(url);
+
+          const decision = await decisionPromise;
+          outputDecision(
+            decision.behavior,
+            decision.feedback,
+            decision.acceptMode,
+          );
+
+          await retry.server.waitForDrain();
+          await new Promise((r) => setTimeout(r, 500));
+          retry.server.stop();
+          removeLock();
+          setTimeout(() => process.exit(0), 50);
+        } else {
+          try {
+            await diffReviewClientPath(retry.port, sessionId, fileDiffs, cwd);
+          } catch {
+            outputDecision(
+              "deny",
+              "IPE server disconnected after retry. Please retry.",
+            );
+          }
+        }
+      } else {
+        throw err;
+      }
+    }
   }
 }
 

--- a/tests/integration/multi-session.test.ts
+++ b/tests/integration/multi-session.test.ts
@@ -269,4 +269,51 @@ describe("multi-session hook flow", () => {
     expect(outA.hookSpecificOutput.decision.behavior).toBe("allow");
     expect(outB.hookSpecificOutput.decision.behavior).toBe("allow");
   }, 15000);
+
+  test("client recovers when server dies during SSE wait", async () => {
+    const port = getUniquePort();
+
+    // Hook 1 starts as server owner
+    const hook1 = spawnHook(
+      makeInput("# Plan 1\n\nFirst", "plan", "die-1"),
+      port,
+    );
+    await waitForServer(hook1.proc.stderr as ReadableStream);
+
+    // Hook 2 joins as client
+    const hook2 = spawnHook(
+      makeInput("# Plan 2\n\nSecond", "plan", "die-2"),
+      port,
+    );
+    await waitForRegistered(hook2.proc.stderr as ReadableStream);
+
+    // Kill server owner immediately — client's SSE breaks
+    hook1.proc.kill();
+    await hook1.proc.exited;
+
+    // Hook 2 should recover: start its own server and become owner
+    // waitForServer reads stderr for "running at" from the retry path
+    const { port: newPort } = await waitForServer(
+      hook2.proc.stderr as ReadableStream,
+    );
+
+    // Approve hook2's session on the new server
+    await fetch(`http://localhost:${newPort}/api/sessions/die-2/approve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ feedback: "" }),
+    });
+
+    const exitCode = await Promise.race([
+      hook2.proc.exited,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("hook2 timeout")), 5000),
+      ),
+    ]);
+    expect(exitCode).toBe(0);
+
+    const out2 = await hook2.stdout();
+    const output2 = JSON.parse(out2.trim());
+    expect(output2.hookSpecificOutput.decision.behavior).toBe("allow");
+  }, 15000);
 });


### PR DESCRIPTION
When the server owner is killed (e.g., Claude Code hook timeout), a client hook connected via SSE would get an instant disconnect and output "deny" without ever opening the browser — causing a fast-timeout loop.

Three fixes:
- Reorder cleanup: stop server before removing lock file so new hooks see the stale lock and start fresh instead of joining a dying server
- Client path now opens the browser (previously, only the server owner did)
- Client path retries once when SSE fails within 2s (dying server race)