### PR TITLE
feat: visible keyboard shortcuts, x for request changes, fix Shift+Tab

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,24 @@
+## Design Context
+
+### Users
+
+Developers using Claude Code who are reviewing AI-generated implementation plans and code diffs. They open IPE mid-workflow — often alongside a terminal and IDE — to carefully read, annotate, and decide on a plan. The interface needs to support focused reading of markdown-rendered plans with inline commenting, similar to a code review. Reading sessions can be quick (30 seconds to approve) or extended (several minutes of careful annotation).
+
+### Brand Personality
+
+**Clean, precise, surgical.** Quiet confidence. Every element earns its place. The tool should feel like a precision instrument — sharp edges, clear hierarchy, nothing decorative. Not cold or sterile, but considered. The kind of interface where you notice the care in the details rather than the details themselves.
+
+### Aesthetic Direction
+
+- **Tone**: Refined minimalism with confident typographic hierarchy. Think: a well-set technical document, not a dashboard.
+- **Theme**: Both dark and light modes, both intentional. Dark for late-night terminal sessions, light for daytime reading. Neither should feel like an afterthought.
+- **Anti-references**: NOT a GitHub clone (should have its own identity). NOT a generic SaaS product (no illustrations, marketing gradients, or decorative fluff). NOT a boring IDE panel (it should feel special when it opens, a moment of clarity in the dev workflow).
+- **References**: The calm focus of iA Writer. The precision of Linear's UI. The reading comfort of a well-typeset technical book.
+
+### Design Principles
+
+1. **Reading first** — Plans are text. Typography, line length, and vertical rhythm matter more than any visual flourish. The interface exists to make markdown readable and annotatable.
+2. **Surgical clarity** — Every UI element has one job. Buttons look like buttons, text looks like text, interactive surfaces are obvious. No ambiguity.
+3. **Quiet until needed** — Chrome and controls recede when reading. They appear with purpose when you need to act (annotate, approve, compare).
+4. **Two contexts, one identity** — Dark and light modes are two expressions of the same design language, not a toggle between two different apps.
+5. **Earns its window** — When IPE opens a browser tab, it should feel worth the context switch. Not just functional — considered.

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -296,7 +296,7 @@
     ) {
       if (submitting || showDiff || showShortcutsHelp) return;
       e.preventDefault();
-      submitDecision("approve", "normal");
+      submitDecision("approve", "auto-approve");
       return;
     }
 
@@ -306,6 +306,13 @@
       if (showDiff || showShortcutsHelp) return;
       e.preventDefault();
       toolbarRef?.openAndFocusComment();
+      return;
+    }
+
+    if (e.key === "x" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (submitting || showDiff || showShortcutsHelp) return;
+      e.preventDefault();
+      toolbarRef?.openForDeny();
       return;
     }
 
@@ -408,6 +415,7 @@
       generalComment = comment;
       submitDecision(action, acceptMode);
     }}
+    onShowShortcuts={() => (showShortcutsHelp = true)}
   />
   <main class="main">
     <PlanViewer

--- a/packages/ui/src/lib/DiffReviewApp.svelte
+++ b/packages/ui/src/lib/DiffReviewApp.svelte
@@ -158,7 +158,7 @@
     ) {
       if (submitting || showShortcutsHelp) return;
       e.preventDefault();
-      submitDecision("approve", "normal");
+      submitDecision("approve", "auto-approve");
       return;
     }
 
@@ -168,6 +168,13 @@
       if (showShortcutsHelp) return;
       e.preventDefault();
       reviewDropdownRef?.openAndFocusComment();
+      return;
+    }
+
+    if (e.key === "x" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (submitting || showShortcutsHelp) return;
+      e.preventDefault();
+      reviewDropdownRef?.openForDeny();
       return;
     }
 
@@ -256,6 +263,12 @@
       {/if}
     </div>
     <div class="toolbar-right">
+      <button
+        class="shortcuts-btn"
+        onclick={() => (showShortcutsHelp = true)}
+        aria-label="Keyboard shortcuts"
+        title="Keyboard shortcuts">?</button
+      >
       <button class="theme-toggle" onclick={onToggleTheme}>
         {theme === "dark" ? "\u2600" : "\u263E"}
       </button>
@@ -372,6 +385,21 @@
     font-size: 0.75rem;
     color: var(--color-text-muted);
     font-style: italic;
+  }
+  .shortcuts-btn {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+  .shortcuts-btn:hover {
+    background: var(--color-bg-overlay);
+    color: var(--color-text-default);
   }
   .theme-toggle {
     background: transparent;

--- a/packages/ui/src/lib/KeyboardShortcutsOverlay.svelte
+++ b/packages/ui/src/lib/KeyboardShortcutsOverlay.svelte
@@ -36,26 +36,30 @@
       <tbody>
         <tr>
           <td class="key"><kbd>Shift</kbd> + <kbd>Tab</kbd></td>
-          <td>Accept plan</td>
+          <td>Accept plan, auto-approve edits</td>
+        </tr>
+        <tr>
+          <td class="key"><kbd>x</kbd></td>
+          <td>Request changes</td>
         </tr>
         <tr>
           <td class="key"><kbd>c</kbd></td>
           <td>Open review panel / comment</td>
         </tr>
         <tr>
-          <td class="key"><kbd>?</kbd></td>
-          <td>Show this help</td>
+          <td class="key"
+            ><kbd>{navigator.platform.includes("Mac") ? "⌘" : "Ctrl"}</kbd> +
+            <kbd>Enter</kbd></td
+          >
+          <td>Submit review / save comment</td>
         </tr>
         <tr>
           <td class="key"><kbd>Escape</kbd></td>
           <td>Close overlay / cancel</td>
         </tr>
         <tr>
-          <td class="key"
-            ><kbd>{navigator.platform.includes("Mac") ? "Cmd" : "Ctrl"}</kbd> +
-            <kbd>Enter</kbd></td
-          >
-          <td>Submit review / save comment</td>
+          <td class="key"><kbd>?</kbd></td>
+          <td>Show this help</td>
         </tr>
       </tbody>
     </table>

--- a/packages/ui/src/lib/ReviewDropdown.svelte
+++ b/packages/ui/src/lib/ReviewDropdown.svelte
@@ -68,6 +68,12 @@
     requestAnimationFrame(() => textareaEl?.focus());
   }
 
+  export function openForDeny() {
+    open = true;
+    action = "deny";
+    requestAnimationFrame(() => textareaEl?.focus());
+  }
+
   let inlineCount = $derived(
     activeCommentCount - (generalComment.trim() ? 1 : 0),
   );
@@ -81,6 +87,7 @@
     {#if activeCommentCount > 0}
       <span class="trigger-badge">{activeCommentCount}</span>
     {/if}
+    <kbd class="kbd-hint">c</kbd>
     <span class="caret">▾</span>
   </button>
 
@@ -110,6 +117,7 @@
         <label class="radio-option">
           <input type="radio" bind:group={action} value="deny" />
           <span class="radio-label">Request changes</span>
+          <kbd class="kbd-inline">x</kbd>
         </label>
       </div>
 
@@ -122,23 +130,31 @@
           <label class="radio-option accept-mode-option">
             <input type="radio" bind:group={acceptMode} value="auto-approve" />
             <span class="radio-label">Approve, auto-accept edits</span>
+            <kbd class="kbd-inline">Shift+Tab</kbd>
           </label>
         </div>
       {/if}
 
-      <button
-        class="btn-submit"
-        class:approve={action === "approve"}
-        disabled={submitting}
-        onclick={() =>
-          onSubmit(
-            action,
-            generalComment,
-            action === "approve" ? acceptMode : undefined,
-          )}
-      >
-        {action === "approve" ? approveLabel : "Request changes"}
-      </button>
+      <div class="submit-row">
+        <button
+          class="btn-submit"
+          class:approve={action === "approve"}
+          disabled={submitting}
+          onclick={() =>
+            onSubmit(
+              action,
+              generalComment,
+              action === "approve" ? acceptMode : undefined,
+            )}
+        >
+          {action === "approve" ? approveLabel : "Request changes"}
+        </button>
+        <span class="submit-hint"
+          ><kbd class="kbd-inline"
+            >{navigator.platform.includes("Mac") ? "⌘" : "Ctrl"}+Enter</kbd
+          ></span
+        >
+      </div>
     </div>
   {/if}
 </div>
@@ -257,9 +273,43 @@
   .accept-mode-option input[type="radio"] {
     accent-color: var(--color-approve-bg);
   }
-  .btn-submit {
+  .kbd-hint {
+    display: inline-block;
+    padding: 1px 5px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 0.65rem;
+    color: rgba(255, 255, 255, 0.5);
+    line-height: 1.4;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+  .kbd-inline {
+    display: inline-block;
+    padding: 1px 5px;
+    background: var(--color-bg-page);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 0.65rem;
+    color: var(--color-text-muted);
+    line-height: 1.4;
+  }
+  .submit-row {
     margin-top: 14px;
-    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .submit-hint {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+  }
+  .btn-submit {
+    flex: 1;
     padding: 8px 16px;
     border-radius: 6px;
     font-size: 0.875rem;

--- a/packages/ui/src/lib/Toolbar.svelte
+++ b/packages/ui/src/lib/Toolbar.svelte
@@ -25,6 +25,7 @@
       generalComment: string,
       acceptMode?: "normal" | "auto-approve",
     ) => void;
+    onShowShortcuts: () => void;
   }
 
   let {
@@ -46,6 +47,7 @@
     generalComment,
     onCommentChange,
     onSubmit,
+    onShowShortcuts,
   }: Props = $props();
 
   let multiSession = $derived(sessions.length > 1);
@@ -54,6 +56,10 @@
 
   export function openAndFocusComment() {
     reviewDropdownRef?.openAndFocusComment();
+  }
+
+  export function openForDeny() {
+    reviewDropdownRef?.openForDeny();
   }
 
   let upgrading = $state(false);
@@ -125,6 +131,12 @@
     {/if}
   </div>
   <div class="toolbar-right">
+    <button
+      class="btn btn-icon"
+      onclick={onShowShortcuts}
+      aria-label="Keyboard shortcuts"
+      title="Keyboard shortcuts">?</button
+    >
     <button
       class="btn btn-secondary"
       onclick={onToggleTheme}
@@ -276,6 +288,18 @@
     font-weight: 500;
     cursor: pointer;
     transition: background 0.15s;
+  }
+  .btn-icon {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    padding: 6px 10px;
+    font-weight: 600;
+  }
+  .btn-icon:hover {
+    background: var(--color-bg-overlay);
+    color: var(--color-text-default);
   }
   .btn-secondary {
     background: transparent;


### PR DESCRIPTION
- Add `x` shortcut to open review panel in "request changes" mode with textarea focused for optional comment before submitting
- Show kbd hints on toolbar buttons (c on Submit review, Shift+Tab on auto-approve option, x on request changes, Cmd+Enter on submit)
- Add `?` button in toolbar for quick access to shortcuts overlay
- Fix Shift+Tab to send auto-approve (matching Claude CLI behavior) instead of normal approve mode

