### PR TITLE
fix: ad-hoc sign macOS binary to prevent Gatekeeper kill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
 
       - run: bun run build
 
+      - name: Ad-hoc sign (macOS)
+        if: runner.os == 'macOS'
+        run: codesign -s - ipe
+
       - name: Rename binary
         shell: bash
         run: mv ipe${{ matrix.ext }} ipe-${{ matrix.target }}${{ matrix.ext }}

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,11 @@ mkdir -p "$IPE_DIR"
 curl -fSL "$DOWNLOAD_URL" -o "$IPE_DIR/ipe"
 chmod +x "$IPE_DIR/ipe"
 
+# Ad-hoc sign on macOS to satisfy Gatekeeper/provenance checks
+if [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; then
+  codesign -f -s - "$IPE_DIR/ipe" 2>/dev/null || warn "Ad-hoc signing failed — binary may be blocked by macOS"
+fi
+
 # Install /diff-review command
 info "Installing /diff-review command..."
 COMMANDS_DIR="$HOME/.claude/commands"


### PR DESCRIPTION
macOS 26+ enforces com.apple.provenance on downloaded binaries and kills unsigned executables. Sign the binary in CI after build and as a fallback in install.sh after download.
