### PR TITLE
ci: split single check into parallel lint/test/e2e/build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
 
       - run: bun install
 
+      - name: Build UI (integration tests import packages/ui/dist/index.html)
+        run: cd packages/ui && bun run build
+
       - run: bun run test
 
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [main]
 
-jobs:
-  check:
-    runs-on: ubuntu-latest
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -17,16 +20,72 @@ jobs:
         with:
           bun-version: latest
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install
+
+      - run: bun run format:check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install
+
+      - run: bun run test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
       - run: bun install
 
       - name: Install Playwright
         run: bunx playwright install --with-deps chromium
 
-      - name: Check formatting
-        run: bun run format:check
+      - run: bun run test:e2e
 
-      - name: Build
-        run: bun run build
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Test
-        run: bun run test:all
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install
+
+      - run: bun run build


### PR DESCRIPTION
## Summary
- Splits the single serial `check` job in `.github/workflows/ci.yml` into four parallel jobs (`lint`, `test`, `e2e`, `build`) so the long pole is one job's runtime instead of the sum.
- Adds top-level `concurrency` group keyed on `github.ref` with `cancel-in-progress: true` so a new push to a PR cancels the prior in-progress run.
- Adds `actions/cache@v4` for `~/.bun/install/cache` keyed on `bun.lock` in each job.

Note: if a branch protection rule on `main` requires the old `check` status, it will need to be updated to require the new job names.

## Test plan
- [x] All four checks (`lint`, `test`, `e2e`, `build`) appear on this PR and run in parallel
- [x] All four pass green
- [x] Push a follow-up commit and confirm the prior run shows as `Cancelled`
- [x] Cache step reports `Cache restored successfully` on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)