### PR TITLE
ci: bump actions/checkout v4 → v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -33,7 +33,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -55,7 +55,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -77,7 +77,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Delete pre-release and tag
         env:
@@ -30,7 +30,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create or update pre-release
         env:
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.tag.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get tag name
         id: tag
         run: echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
@@ -53,7 +53,7 @@ jobs:
       TAG_NAME: ${{ needs.create-release.outputs.tag_name || github.event.release.tag_name || github.event.inputs.tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.TAG_NAME }}
 


### PR DESCRIPTION
## What

Bumps `actions/checkout@v4` → `@v5` across all three workflows (`ci.yml`, `pr-build.yml`, `release.yml`).

## Why

`actions/checkout@v4` runs on Node 20, which the v0.1.18 release run flagged as deprecated:

> Node.js 20 actions are deprecated… Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

v5 runs on Node 24, clearing the warning before the forced cutover.

## Scope

- Only `actions/checkout` changes — `oven-sh/setup-bun@v2` and `actions/cache@v4` are already on their latest majors and were not flagged.
- No behavioral change; checkout v5 is API-compatible with the existing usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)